### PR TITLE
Add Margin multiplier to state

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -63,6 +63,7 @@ fn restore_windows(manager: &mut Manager, old_manager: &Manager) {
         {
             window.set_floating(old.floating());
             window.set_floating_offsets(old.get_floating_offsets());
+            window.set_margin_multiplier(old.margin_multiplier);
             window.normal = old.normal;
             window.tags = old.tags.clone();
         }


### PR DESCRIPTION
I looked into remembering the window order on reload, however to do so (with my current know-how) is inefficient as I think you would have to clear the manager.windows list then add the windows back in the same order they are in the old_manager (as on recreation of the manager the order xlib gives the windows in isn't consistent).